### PR TITLE
allow @ to be appended to filenames

### DIFF
--- a/Vendor/Uploader.php
+++ b/Vendor/Uploader.php
@@ -682,7 +682,7 @@ class Uploader {
 			$ext = $this->_data[$this->_current]['ext'];
 		}
 
-		$patterns = array('/[^-_.a-zA-Z0-9\/\s]/i', '/[\s]/');
+		$patterns = array('/[^-_.@a-zA-Z0-9\/\s]/i', '/[\s]/');
 		$name = str_replace(array('.' . $ext, '.' . strtoupper($ext)), '', $name);
 		$name = preg_replace($patterns, array('', '_'), $name);
 


### PR DESCRIPTION
Hi Miles,

Thanks for the great plugin. I think you should allow @ as one of the characters that can be appended to filenames. Some people may want to append "@2x" modifier to filenames when building Retina optimized websites. As recommended by Apple:

https://developer.apple.com/library/ios/#documentation/2DDrawing/Conceptual/DrawingPrintingiOS/SupportingHiResScreens/SupportingHiResScreens.html
