### PR TITLE
Fix for deleteImages with multiple uploads on a single model.

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -129,6 +129,9 @@ class AttachmentBehavior extends ModelBehavior {
 	 */
 	public function setup(Model $model, $settings = array()) {
 		if ($settings) {
+			if (!isset($this->_columns[$model->alias])) {
+				$this->_columns[$model->alias] = array();
+			}
 			foreach ($settings as $field => $attachment) {
 				$attachment = Set::merge($this->_defaultSettings, $attachment + array(
 					'dbColumn' => $field
@@ -165,7 +168,7 @@ class AttachmentBehavior extends ModelBehavior {
 				}
 
 				$this->settings[$model->alias][$field] = $attachment;
-				$this->_columns[$model->alias] = $columns;
+				$this->_columns[$model->alias] += $columns;
 			}
 		}
 	}


### PR DESCRIPTION
The `$this->_columns[$model->alias]` was being overwritten for each attachment behavior instead of being the combination of all of them.  This lead to a situation where I could only use `deleteImages` on the last behavior added to my `$actsAs`.
