### PR TITLE
Fix PHP strict warning 2048

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -211,7 +211,7 @@ class AttachmentBehavior extends ModelBehavior {
      * @param bool $primary
      * @return array
      */
-    public function afterFind(Model $model, $results, $primary) {
+    public function afterFind(Model $model, $results, $primary=false) {
         $alias = $model->alias;
 
         foreach ($results as $i => $data) {


### PR DESCRIPTION
PHP throws a warning 2048 "Declaration of AttachementBehavior::afterFind() sould be compatible with ModelBehavior::afterFind()" in STRICT mode
