### PR TITLE
New setting: "cleanup"

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -100,7 +100,8 @@ class AttachmentBehavior extends ModelBehavior {
         'transformers' => array(),
         'transport' => array(),
         'transporters' => array(),
-        'curl' => array()
+        'curl' => array(),
+        'cleanup' => true
     );
 
     /**
@@ -737,6 +738,12 @@ class AttachmentBehavior extends ModelBehavior {
 
         foreach ($fields as $column => $value) {
             if (empty($data[$model->alias][$column])) {
+                continue;
+            }
+            
+            $attachment = $this->_settingsCallback($model, $this->settings[$model->alias][$column]);
+
+            if (!$attachment['cleanup']) {
                 continue;
             }
 


### PR DESCRIPTION
There are situations where you do not want to delete a previously uploaded file when uploading a new one into the same column. A simple example would be a project where the customer wants an archive of all photos that have been uploaded by the application's users, including those that have been uploaded or replaced.

This problem could be solved with a file versioning table, but that is usually unnecessarily complicated.

I therefore added a new setting "cleanup" which, if set to false, prevents the old file from being deleted during cleanup.
