### PR TITLE
Check if settings exist before calling _settingsCallback in _cleanupOldFiles

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -747,10 +747,12 @@ class AttachmentBehavior extends ModelBehavior {
                 continue;
             }
 
-            $attachment = $this->_settingsCallback($model, $this->settings[$model->alias][$column]);
+            if (!empty($this->settings[$model->alias][$column])) {
+                $attachment = $this->_settingsCallback($model, $this->settings[$model->alias][$column]);
 
-            if (!$attachment['cleanup']) {
-                continue;
+                if (!$attachment['cleanup']) {
+                    continue;
+                }
             }
 
             // Delete if previous value doesn't match new value


### PR DESCRIPTION
Sorry, in my previous pull request #158 I forgot to add a check whether settings for a column exist before calling `_settingsCallback`. I added this now.
