### PR TITLE
disable order by

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -704,7 +704,8 @@ class AttachmentBehavior extends ModelBehavior {
         $results = $model->find($type, array(
             'conditions' => $where,
             'contain' => false,
-            'recursive' => -1
+            'recursive' => -1,
+            'order' => ''
         ));
 
         $model->virtualFields = $virtual;


### PR DESCRIPTION
ordering is not necessary and can cause a problem when using the default order which specified a virtualField
