### PR TITLE
_cleanupOldFiles(): using custom dbColumn looks for wrong settings

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -782,8 +782,8 @@ class AttachmentBehavior extends ModelBehavior {
                 continue;
             }
 
-            if (!empty($this->settings[$model->alias][$column])) {
-                $attachment = $this->_settingsCallback($model, $this->settings[$model->alias][$column]);
+            if (!empty($this->settings[$model->alias][$columns[$column]])) {
+                $attachment = $this->_settingsCallback($model, $this->settings[$model->alias][$columns[$column]]);
 
                 if (!$attachment['cleanup']) {
                     continue;


### PR DESCRIPTION
When `$this->_cleanupOldFiles($model, $cleanup);` is called from `beforeSave()`, it is passed the model and a hash where the key is a column name.

This column name is derived from the models settings `dbColumn`, if present.

In the `foreach` loop it tries to get the columns settings:

``` PHP
foreach ($fields as $column => $value) {
  if (empty($data[$model->alias][$column])) {
    continue;
  }
  if (!empty($this->settings[$model->alias][$column])) {
    $attachment = $this->_settingsCallback($model, $this->settings[$model->alias][$column]);
    if (!$attachment['cleanup']) {
      continue;
    }
  }
```

However, it tries to look up the custom column name form `dbColumn` which has no settings in the models `Uploader.Attachment` settings:

``` PHP
  var $actsAs = [
    'Uploader.Attachment' => [
      'upload_image' => [
        ...
        'dbColumn' => 'my_custom_column_name',
```

The lookup performed however is (literal example):

``` PHP
  if (!empty($this->settings[$model->alias]['my_custom_column_name')) {
```

which won't work; it should be the original and not the mapped column name I think:

``` PHP
  if (!empty($this->settings[$model->alias]['upload_image')) {
```

This change fixes that.
