### PR TITLE
Reset property so it doesn't leak to other models

### DIFF
--- a/Model/Behavior/FileValidationBehavior.php
+++ b/Model/Behavior/FileValidationBehavior.php
@@ -333,6 +333,7 @@ class FileValidationBehavior extends ModelBehavior {
     public function afterValidate(Model $model) {
         if ($this->_tempFile) {
             $this->_tempFile->delete();
+            $this->_tempFile = null;
         }
 
         return true;


### PR DESCRIPTION
If the FileValidation is used in multiple models which are validated
within a single request, since Behaviours are effectively singletons,
their internal state leaks over to the next model.

This prevents $_tmpFile still being set for the next model; otherwise
this file would be tried to be deleted again in the next model validation
which does not exist anymore.

---

We observed this problem when saving two models successively which both used FileValidation. Only in the first model a file was attached, the second model had no file (but validation rules) and these were executed. The led to the leakage of `_tempFile` and this a duplicate deletion attempt which failed.

Implementation detail: although the `Transit` package uses the following code:

``` PHP
    public function delete() {
        $this->reset();

        return @unlink($this->_path);
    }
```

which actually prevents warnings being generated, this can change with custom error handlers and thus still generate warnings depending on the environment.
