### PR TITLE
Include 'overwirte' parameter to call rename() function

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -684,7 +684,7 @@ class AttachmentBehavior extends ModelBehavior {
             $file->move($options['uploadDir'], $options['overwrite']);
         }
 
-        $file->rename($nameCallback, $options['append'], $options['prepend']);
+        $file->rename($nameCallback, $options['append'], $options['prepend'], $options['overwrite']);
 
         return (string) $options['finalPath'] . $file->basename();
     }


### PR DESCRIPTION
To Call rename($name = '', $append = '', $prepend = '', $overwrite = false) , we need to specify the $options['overwrite'] parameter, otherwise overwrite is always false.
